### PR TITLE
Release 0.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <div align="center">
+<!-- mcp-name: io.github.bx33661/wireshark-mcp -->
 
 <br>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,4 +1,5 @@
 <div align="center">
+<!-- mcp-name: io.github.bx33661/wireshark-mcp -->
 
 <br>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wireshark-mcp"
-version = "0.6.4"
+version = "0.6.5"
 description = "A production-grade Model Context Protocol (MCP) server for Wireshark"
 readme = "README.md"
 keywords = ["mcp", "wireshark", "tshark", "packet-analysis", "network", "pcap", "model-context-protocol", "llm", "security"]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.bx33661/wireshark-mcp",
+  "description": "Professional network analysis with tshark. Security audits, deep-dives, and threat detection.",
+  "repository": {
+    "url": "https://github.com/bx33661/Wireshark-MCP",
+    "source": "github"
+  },
+  "version": "0.6.5",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "wireshark-mcp",
+      "version": "0.6.5",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "websiteUrl": "https://github.com/bx33661/Wireshark-MCP"
+}

--- a/src/wireshark_mcp/__init__.py
+++ b/src/wireshark_mcp/__init__.py
@@ -2,4 +2,4 @@
 Wireshark MCP - A Model Context Protocol server for Wireshark.
 """
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,8 @@
 """Tests for server bootstrap behavior."""
 
+from importlib import metadata
+
+import wireshark_mcp
 import wireshark_mcp.server as server
 
 
@@ -45,3 +48,7 @@ class TestWindowsEventLoop:
         server._configure_windows_event_loop()
 
         assert applied == []
+
+
+def test_package_version_matches_installed_metadata():
+    assert wireshark_mcp.__version__ == metadata.version("wireshark-mcp")

--- a/uv.lock
+++ b/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "wireshark-mcp"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Summary
- add MCP registry verification comments to both READMEs
- bump package metadata and lockfile to 0.6.5
- add server.json for MCP Registry publishing
- fix CLI package version output and add a version consistency test

## Verification
- uv run pytest
- uv run wireshark-mcp --version
- uv run python -m wireshark_mcp.server --version
- uv build