### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ wireshark-mcp uninstall
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/bx33661-wireshark-mcp).
+
 ## Platform Setup
 
 Use this section when you want the shortest reliable path to a working setup on each OS.


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/bx33661-wireshark-mcp).